### PR TITLE
Add repository link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Martin Hanzík <martin@hanzik.com>"]
 description = "Rust wrapper for duktape"
 license = "MIT"
+repository = "https://github.com/martinhanzik/goose"
 
 [workspace]
 members = ["duktape-sys"]


### PR DESCRIPTION
Needed for the link to show up on crates.io...